### PR TITLE
[2024-03-14] heewon #3

### DIFF
--- a/Programmers/도넛과 막대 그래프/heewon.py
+++ b/Programmers/도넛과 막대 그래프/heewon.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+def solution(edges):
+    answer = [0, 0, 0, 0]
+
+    # node in, out 선언
+    node_in = defaultdict(list)
+    node_out = defaultdict(list)
+
+    # node 집합 생성
+    nodes = set()
+    
+    # edges로 node in, out
+    for a, b in edges:
+        node_out[a].append(b)
+        node_in[b].append(a)
+        nodes.add(a)
+        nodes.add(b)
+    
+    # 모양 갯수
+    shape_cnt = 0
+    
+    # 모든 노드를 확인
+    for node in nodes:
+        # 생성한 정점의 번호 와 모양 갯수 찾기
+        if not node_in[node] and len(node_out[node]) >= 2:
+            answer[0] = node
+            shape_cnt = len(node_out[node])
+        # 막대 모양 그래프 갯수 찾기
+        elif len(node_out[node]) == 0: answer[2] += 1
+        # 8자 모양 그래프 갯수 찾기
+        elif len(node_out[node]) + len(node_in[node]) >= 4: answer[3] += 1
+    
+    # 도넛 모양 그래프 갯수 찾기
+    answer[1] = shape_cnt - answer[2] - answer[3]
+    
+    return answer

--- a/Programmers/도넛과 막대 그래프/heewon.py
+++ b/Programmers/도넛과 막대 그래프/heewon.py
@@ -35,3 +35,61 @@ def solution(edges):
     answer[1] = shape_cnt - answer[2] - answer[3]
     
     return answer
+
+# 지수님 방법 보고 시도 -시간 복잡도 감소
+
+from collections import defaultdict, deque
+
+def validate(root, st_dict, en_dict):
+    nodes = {root}
+    queue = deque([root])
+    # 노드의 수 / 간선의 수
+    node_cnt = 0
+    edge_cnt = 0
+
+    # BFS로 그래프에 포함된 정점 찾기(DFS 재귀 활용시 최대 재귀 깊이 에러)
+    while queue:
+        cur = queue.popleft()
+        node_cnt += 1
+        edge_cnt += len(st_dict[cur])
+
+        for v in st_dict[cur]:
+            if v not in nodes:
+                nodes.add(v)
+                queue.append(v)
+
+    # 도넛의 조건
+    if node_cnt == edge_cnt:
+        return 1
+    # 8자의 조건
+    elif node_cnt + 1 == edge_cnt:
+        return 3
+    # 나머지 경우 = 막대 경우
+    else:
+        return 2
+
+def solution(edges):
+    # 생성된 정점 찾기
+    st_dict = defaultdict(list)
+    en_dict = defaultdict(int)
+
+    for st, en in edges:
+        st_dict[st].append(en)
+        en_dict[en] += 1
+
+    for st, lst in st_dict.items():
+        if len(lst) >= 2 and st not in en_dict:
+            root = st
+
+    answer = [root, 0, 0, 0]  # [정점, 도넛, 막대, 8자]
+
+    # 생성된 정점에서 뻗은 간선 제거
+    for en in st_dict[root]:
+        en_dict[en] -= 1
+
+    # 그래프 탐색
+    for other_root in st_dict[root]:
+        idx = validate(other_root, st_dict, en_dict)
+        answer[idx] += 1
+
+    return answer


### PR DESCRIPTION
## 1st Method

### 변수 설명
- `node_in`: Node로 들어오는 노드들
- `node_out`: Node에서 나가는 방향의 노드들
- `shape_cnt`: 모든 모양의 개수
- `nodes`: 모든 노드의 집합

### 접근 방식
- `node_in`, `node_out`, `nodes` 구하기
- 모든 노드를 탐색하여 모양 개수 찾기
- 각각의 모양의 규칙
  - 생성한 정점
    - `node_in`이 없고 `node_out`이 2개 이상, 
  - 막대 모양
    - 노드의 입출의 합이 1이다 -> wrong -> why? 막대 모양의 중간과 생성한 정점이 연결되면 2개로 카운트 됨
    - `node_out`이 0 -> 항상 1개 존재하는 막대의 끝 부분 카운트
  - 8자 모양
    - `node_in >=2 and node_out >= 2` -> 8자 모양의 중심으로 카운트
  - 도넛 모양
    - 조건이 다른 모양과 겹침 -> 전체 모양 - 막대 모양 - 8자 모양

### 사용한 모듈
`defaultdict`

## 2nd Method
### 접근 방식
- 노드의 개수와 간선의 개수로 모양을 정하기 가능
- 지수님의 코드 참고
- 문제의 조건을 사용
  - 크기가 n인 도넛 모양 그래프는 n개의 정점과 n개의 간선이 있습니다.
    - 노드의 수와 간선의 수가 같으면 도넛
  - 크기가 n인 막대 모양 그래프는 n개의 정점과 n-1개의 간선이 있습니다.
    - BFS 방식이라 나머지 경우
  - 크기가 n인 8자 모양 그래프는 2n+1개의 정점과 2n+2개의 간선이 있습니다.
    - 노드의 수 + 1 = 간선의 수

### 사용한 모듈
`defaultdict`, `deque`

#3