### PR TITLE
[2024-04-17] jisu #47

### DIFF
--- a/Programmers/연속된 부분 수열의 합/jisu.py
+++ b/Programmers/연속된 부분 수열의 합/jisu.py
@@ -1,0 +1,45 @@
+"""
+start : 2024-04-17 16:55
+end : 2024-04-17 17:20
+
+- 오름차순 정렬
+- 임의의 두 인덱스의 원소와 그 사이의 원소를 모두 포함하는 부분수열 구하기
+- 부분 수열의 합은 k, 여러개인 경우 길이가 짧고, 앞쪽에 있는 수열
+
+- 투포인터 냄새가 솔솔 나쥬?
+- 매번 sum을 구하면 연산량이 너무 큼 -> weighted_sum으로 합계 관리
+    - 초기 left 0 / right 0 으로 세팅 (k가 sequence[0]인 엣지케이스)
+    - weighted_sum < k 인 경우 right를 늘려 수를 하나 합산
+    - weighted_sum > k 인 경우 left를 늘려 왼쪽 수를 하나 제거
+"""
+from typing import List
+
+
+def solution(sequence: List[int], k: int) -> List[int]:
+    left, right = 0, 0
+    weighted_sum = sequence[0]
+    min_length = 1000001        # 최대 길이로 초기화
+    answer = []                 # 명시적 초기화
+
+    while left <= right:
+        # 동일 length라면 먼저 w_sum == k인 경우가 답
+        # 답을 찾아도, 이후에 더 짧은 length 고려를 위해 계속 진행해야 함
+        if weighted_sum == k and right - left + 1 < min_length:
+            answer = [left, right]
+            min_length = right - left + 1
+
+        # 부분 수열 합이 더 작은 경우 오른쪽 수 포함시키기
+        if weighted_sum < k:
+            right += 1
+
+            # 리스트 끝에 다다른경우 더이상 답은 될 수 없음
+            if right >= len(sequence):
+                break
+            weighted_sum += sequence[right]
+
+        # 부분 수열 합이 더 큰 경우 왼쪽 수 제거시키기
+        else:
+            weighted_sum -= sequence[left]
+            left += 1
+
+    return answer


### PR DESCRIPTION
### PR Summary
<!-- PR 내용을 간략하게 소개해주세요 -->
- 투포인터 접근
- 매번 sum을 구하면 연산량이 너무 큼 -> weighted_sum으로 합계 관리
    - 초기 left 0 / right 0 으로 세팅 (k가 sequence[0]인 엣지케이스)
    - weighted_sum < k 인 경우 right를 늘려 수를 하나 합산
    - weighted_sum > k 인 경우 left를 늘려 왼쪽 수를 하나 제거

<details>
<summary>채점 결과</summary>
<div markdown="1">

테스트 1 〉 | 통과 (0.01ms, 10.5MB)
-- | --
테스트 2 〉 | 통과 (0.01ms, 10.6MB)
테스트 3 〉 | 통과 (0.05ms, 10.6MB)
테스트 4 〉 | 통과 (0.28ms, 10.6MB)
테스트 5 〉 | 통과 (4.52ms, 10.8MB)
테스트 6 〉 | 통과 (8.83ms, 11.1MB)
테스트 7 〉 | 통과 (19.36ms, 12MB)
테스트 8 〉 | 통과 (32.50ms, 13.7MB)
테스트 9 〉 | 통과 (110.50ms, 17MB)
테스트 10 〉 | 통과 (205.00ms, 27MB)
테스트 11 〉 | 통과 (283.78ms, 43.7MB)
테스트 12 〉 | 통과 (330.17ms, 43.4MB)
테스트 13 〉 | 통과 (325.95ms, 43.4MB)
테스트 14 〉 | 통과 (302.74ms, 43.5MB)
테스트 15 〉 | 통과 (335.79ms, 43.6MB)
테스트 16 〉 | 통과 (183.49ms, 51.9MB)
테스트 17 〉 | 통과 (456.46ms, 51.9MB)
테스트 18 〉 | 통과 (0.01ms, 10.7MB)
테스트 19 〉 | 통과 (0.01ms, 10.6MB)
테스트 20 〉 | 통과 (0.01ms, 10.7MB)
테스트 21 〉 | 통과 (0.01ms, 10.5MB)
테스트 22 〉 | 통과 (0.01ms, 10.6MB)
테스트 23 〉 | 통과 (0.01ms, 10.5MB)
테스트 24 〉 | 통과 (297.67ms, 19MB)
테스트 25 〉 | 통과 (204.11ms, 18.9MB)
테스트 26 〉 | 통과 (361.10ms, 18.8MB)
테스트 27 〉 | 통과 (315.41ms, 19MB)
테스트 28 〉 | 통과 (262.50ms, 18.9MB)
테스트 29 〉 | 통과 (410.17ms, 18.9MB)
테스트 30 〉 | 통과 (364.79ms, 51.8MB)
테스트 31 〉 | 통과 (0.00ms, 10.5MB)
테스트 32 〉 | 통과 (0.01ms, 10.7MB)
테스트 33 〉 | 통과 (0.00ms, 10.5MB)
테스트 34 〉 | 통과 (0.01ms, 10.7MB)

</div>
</details>

### ISSUE NUMBER
<!-- 이슈 번호를 입력해주세요 -->
- #47 